### PR TITLE
Changing action names for 324131137411 on zigbee2mqtt

### DIFF
--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -372,18 +372,18 @@ variables:
         button_down_long: [down-hold]
         button_down_release: [down-hold-release]
       philips_324131137411:
-        button_on_short: [on-press] # NOT TESTED
-        button_on_long: [on-hold]
-        button_on_release: [on-hold-release]
-        button_off_short: [off-press] # NOT TESTED
-        button_off_long: [off-hold]
-        button_off_release: [off-hold-release]
-        button_up_short: [up-press] # NOT TESTED
-        button_up_long: [up-hold]
-        button_up_release: [up-hold-release]
-        button_down_short: [down-press] # NOT TESTED
-        button_down_long: [down-hold]
-        button_down_release: [down-hold-release]
+        button_on_short: [on_press]
+        button_on_long: [on_hold]
+        button_on_release: [on_hold_release]
+        button_off_short: [off_press]
+        button_off_long: [off_hold]
+        button_off_release: [off_press_release]
+        button_up_short: [up_press]
+        button_up_long: [up_hold]
+        button_up_release: [up_hold_release]
+        button_down_short: [down_press]
+        button_down_long: [down_hold]
+        button_down_release: [down_hold_release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id][dimmer_model]["button_on_short"] }}'


### PR DESCRIPTION
Note on testing: This PR has so far ONLY been tested on:

- [ ] deCONZ
- [ ] ZHA 
- [x] Zigbee2MQTT

## Proposed change\*

1. Add support for 324131137411 on zigbee2mqtt by changing the action names for this model

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
